### PR TITLE
Release 0.7.0

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/VIPER-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/VIPER-Package.xcscheme
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1250"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "VIPER"
+               BuildableName = "VIPER"
+               BlueprintName = "VIPER"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "viper-tools"
+               BuildableName = "viper-tools"
+               BlueprintName = "viper-tools"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "VIPERTests"
+               BuildableName = "VIPERTests"
+               BlueprintName = "VIPERTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "VIPERTests"
+               BuildableName = "VIPERTests"
+               BlueprintName = "VIPERTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "viper-tools"
+            BuildableName = "viper-tools"
+            BlueprintName = "viper-tools"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "viper-tools"
+            BuildableName = "viper-tools"
+            BlueprintName = "viper-tools"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/VIPER.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/VIPER.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1250"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "VIPER"
+               BuildableName = "VIPER"
+               BlueprintName = "VIPER"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "VIPERTests"
+               BuildableName = "VIPERTests"
+               BlueprintName = "VIPERTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "VIPERTests"
+               BuildableName = "VIPERTests"
+               BlueprintName = "VIPERTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "VIPER"
+            BuildableName = "VIPER"
+            BlueprintName = "VIPER"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/viper-tools.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/viper-tools.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1250"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "viper-tools"
+               BuildableName = "viper-tools"
+               BlueprintName = "viper-tools"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "viper-tools"
+            BuildableName = "viper-tools"
+            BlueprintName = "viper-tools"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "viper-tools"
+            BuildableName = "viper-tools"
+            BlueprintName = "viper-tools"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "VIPER",
     platforms: [
-        .macOS(.v10_15), .iOS(.v13), .tvOS(.v13),
+        .macOS(.v10_10), .iOS(.v10), .tvOS(.v10),
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # VIPER
 
 [![Swift](https://img.shields.io/badge/swift-5.1-f16d39)](https://developer.apple.com/swift/)
-[![Platform](https://img.shields.io/badge/platform-iOS%20%7C%20macOS%20%7C%20tvOS-lightgrey)](https://developer.apple.com/ios/)
+[![Platform](https://img.shields.io/badge/platform-iOS%20%7C%20macOS%20%7C%20tvOS-lightgrey)](https://developer.apple.com/)
 [![Releases](https://img.shields.io/github/v/tag/thomverbeek/VIPER?label=release)](https://github.com/thomverbeek/VIPER/releases)
 
 VIPER is a lightweight [software architecture](https://martinfowler.com/architecture/) framework for Swift.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Swift](https://img.shields.io/badge/swift-5.1-f16d39)](https://developer.apple.com/swift/)
 [![Platform](https://img.shields.io/badge/platform-iOS%20%7C%20macOS%20%7C%20tvOS-lightgrey)](https://developer.apple.com/)
 [![Releases](https://img.shields.io/github/v/tag/thomverbeek/VIPER?label=release)](https://github.com/thomverbeek/VIPER/releases)
+[![Swift Package Manager](https://img.shields.io/badge/spm-compatible-hotpink)](https://swift.org/package-manager)
 
 VIPER is a lightweight [software architecture](https://martinfowler.com/architecture/) framework for Swift.
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,8 @@
 
 # VIPER
 
-![Swift](https://img.shields.io/badge/swift-5.1-f16d39)
-[![iOS](https://img.shields.io/badge/iOS-13-brightgreen)](https://developer.apple.com/ios/)
-[![macOS](https://img.shields.io/badge/macos-10.15-brightgreen)](https://developer.apple.com/macos/)
-[![tvOS](https://img.shields.io/badge/tvos-13-brightgreen)](https://developer.apple.com/tvos/)
+[![Swift](https://img.shields.io/badge/swift-5.1-f16d39)](https://developer.apple.com/swift/)
+[![Platform](https://img.shields.io/badge/platform-iOS%20%7C%20macOS%20%7C%20tvOS-lightgrey)](https://developer.apple.com/ios/)
 [![Releases](https://img.shields.io/github/v/tag/thomverbeek/VIPER?label=release)](https://github.com/thomverbeek/VIPER/releases)
 
 VIPER is a lightweight [software architecture](https://martinfowler.com/architecture/) framework for Swift.
@@ -76,14 +74,14 @@ There are numerous implementations out in the wild that try to meet these requir
 
 ### _“Simplicity is the ultimate sophistication”_
 
-This framework leverages a combination of generics, static scopes and functional reactive programming principles to distill VIPER down to a single file of under a hundred lines of code. Check out [`VIPER.swift`](https://github.com/thomverbeek/VIPER/blob/master/Sources/VIPER/VIPER.swift). 
+This framework leverages a combination of generics, static scopes and functional reactive programming principles to distill VIPER down to a single file of under 300 lines of code, including comments. Check out [`VIPER.swift`](https://github.com/thomverbeek/VIPER/blob/master/Sources/VIPER/VIPER.swift). 
 
 - [x] It allows the compiler to help guide beginners, yet provides swiss-army flexibility to advancers.
 - [x] It fits VIPER components together like lock and key, without needing to force-cast between types.
 - [x] It automates concepts like assembly and weak relationships so you don't have to.
 - [x] It extracts assembly responsibility from the `Router` and grants it to the `Module`.
-- [x] It uses `Entities` to define the dependencies of an `Interactor`, and `Builder` to provide dependency injection to the `Router` for navigation.
-- [x] It designates the `Interactor` as the holder of state, and exchanges the `Presenter` with the `Interactor` in the assembly. This allows a uni-directional data flow from `View` to `Interactor` to `Presenter` to `View`, more closely in line with the Clean Architecture.
+- [x] It uses `Entities` to define the dependencies of an `Interactor`, and `Builder` to provide dependency injection to the `Router`.
+- [x] It designates the `Interactor` as the holder of state, and uses a PresenterModel to communicate between the business logic and presentation logic layers. Presenters use the PresenterModel to consult their state and update their ViewModel without exposing the Entity layer. This setup embraces modern practices like Reactive programming using Combine.
 
 All this results in a VIPER architecture implementation that's simple and sophisticated. For that reason, it's simply called "VIPER".
 

--- a/Sources/VIPER/VIPER.swift
+++ b/Sources/VIPER/VIPER.swift
@@ -1,6 +1,12 @@
 import Foundation
 import ObjectiveC
 
+public typealias VIPERModule = Module
+public typealias VIPERView = View
+public typealias VIPERInteractor = Interactor
+public typealias VIPERPresenter = Presenter
+public typealias VIPERRouter = Router
+
 /**
  A VIPER View represents the UI logic of your screen.
  

--- a/Sources/VIPER/VIPER.swift
+++ b/Sources/VIPER/VIPER.swift
@@ -232,7 +232,7 @@ public final class Module<View: VIPER.View, Interactor: VIPER.Interactor, Presen
     View == Router.View
 {
     
-    public typealias Components = (view: View, interactor: Interactor, presenter: Presenter, router: Router)
+    internal typealias Components = (view: View, interactor: Interactor, presenter: Presenter, router: Router)
     
     private init() {}
     

--- a/Sources/VIPERCommandLine/Templates/Interactor.swift
+++ b/Sources/VIPERCommandLine/Templates/Interactor.swift
@@ -11,20 +11,15 @@ import VIPER
 
 extension \(moduleName) {
 
-    class Interactor<Router>: VIPERInteractor {
+    class Interactor: VIPERInteractor {
         
-        let presenter: CurrentValueSubject<PresenterModel, Never>
-        let router = PassthroughSubject<Navigation, Never>()
+        let presenterModel: Example.PresenterModel
         
         required init(entities: Entities) {
-            presenter = .init(Self.generatePresenterModel())
+            self.presenterModel = PresenterModel()
         }
         
-        private static func generatePresenterModel() -> PresenterModel {
-            return PresenterModel()
-        }
-        
-        func receive(userInteraction: UserInteraction) {
+        func receive(useCase: UseCase) {
             
         }
         

--- a/Sources/VIPERCommandLine/Templates/Interactor.swift
+++ b/Sources/VIPERCommandLine/Templates/Interactor.swift
@@ -5,15 +5,13 @@ struct Interactor: Template {
     static func contents(moduleName: String, operatingSystem: OperatingSystem) -> String {
         return
 """
-import Combine
-
 import VIPER
 
 extension \(moduleName) {
 
-    class Interactor: VIPERInteractor {
+    class Interactor: VIPER.Interactor {
         
-        let presenterModel: Example.PresenterModel
+        let presenterModel: PresenterModel
         
         required init(entities: Entities) {
             self.presenterModel = PresenterModel()

--- a/Sources/VIPERCommandLine/Templates/Module.swift
+++ b/Sources/VIPERCommandLine/Templates/Module.swift
@@ -33,7 +33,7 @@ public protocol Builder {
 public enum \(moduleName) {
 
     public func assemble(entities: Entities, builder: Builder) -> \(view) {
-        return VIPERModule<View, Interactor<Router>, Presenter, Router>.assemble(entities: entities, builder: builder)
+        return VIPERModule<View, Interactor, Presenter, Router>.assemble(entities: entities, builder: builder)
     }
 
     public struct Entities {
@@ -45,6 +45,10 @@ public enum \(moduleName) {
     }
     
     enum UserInteraction {
+        
+    }
+
+    enum UseCase {
         
     }
     

--- a/Sources/VIPERCommandLine/Templates/Module.swift
+++ b/Sources/VIPERCommandLine/Templates/Module.swift
@@ -33,7 +33,7 @@ public protocol Builder {
 public enum \(moduleName) {
 
     public func assemble(entities: Entities, builder: Builder) -> \(view) {
-        return VIPERModule<View, Interactor, Presenter, Router>.assemble(entities: entities, builder: builder)
+        return Module<View, Interactor, Presenter, Router>.assemble(entities: entities, builder: builder)
     }
 
     public struct Entities {

--- a/Sources/VIPERCommandLine/Templates/Presenter.swift
+++ b/Sources/VIPERCommandLine/Templates/Presenter.swift
@@ -5,20 +5,21 @@ struct Presenter: Template {
     static func contents(moduleName: String, operatingSystem: OperatingSystem) -> String {
         return
 """
-import Combine
-
 import VIPER
 
 extension \(moduleName) {
 
-    class Presenter: VIPERPresenter {
+    class Presenter: VIPER.Presenter {
         
+        typealias UseCase = \(moduleName).UseCase
+        typealias Navigation = \(moduleName).Navigation
+
         let viewModel: ViewModel
-        let interactor = PassthroughSubject<UseCase, Never>()
-        let router = PassthroughSubject<Navigation, Never>()
         
         required init(presenterModel: PresenterModel) {
             self.viewModel = ViewModel()
+
+            // Bind to the presenterModel
         }
         
         func receive(userInteraction: UserInteraction) {

--- a/Sources/VIPERCommandLine/Templates/Presenter.swift
+++ b/Sources/VIPERCommandLine/Templates/Presenter.swift
@@ -5,16 +5,26 @@ struct Presenter: Template {
     static func contents(moduleName: String, operatingSystem: OperatingSystem) -> String {
         return
 """
+import Combine
+
 import VIPER
 
 extension \(moduleName) {
 
     class Presenter: VIPERPresenter {
-            
-        static func map(input presenterModel: PresenterModel) -> ViewModel {
-            return ViewModel()
+        
+        let viewModel: ViewModel
+        let interactor = PassthroughSubject<UseCase, Never>()
+        let router = PassthroughSubject<Navigation, Never>()
+        
+        required init(presenterModel: PresenterModel) {
+            self.viewModel = ViewModel()
         }
         
+        func receive(userInteraction: UserInteraction) {
+            
+        }
+                
     }
 
 }

--- a/Sources/VIPERCommandLine/Templates/Router.swift
+++ b/Sources/VIPERCommandLine/Templates/Router.swift
@@ -5,21 +5,21 @@ struct Router: Template {
     static func contents(moduleName: String, operatingSystem: OperatingSystem) -> String {
         return
 """
-import Foundation
-
 import VIPER
 
 extension \(moduleName) {
     
-    class Router: VIPERRouter {
-            
+    class Router: VIPER.Router {
+
+        typealias View = \(moduleName).View
+
         let builder: Builder
         
         required init(builder: Builder) {
             self.builder = builder
         }
         
-        func receive(navigation: Navigation, for view: View) {
+        func receive(navigation: Navigation) {
             
         }
         

--- a/Sources/VIPERCommandLine/Templates/View.swift
+++ b/Sources/VIPERCommandLine/Templates/View.swift
@@ -23,16 +23,14 @@ struct View: Template {
         return
 """
 import \(framework)
-import Combine
 
 import VIPER
         
 extension \(moduleName) {
 
-    class View: \(view), VIPERView {
+    class View: \(view), VIPER.View {
         
-        let presenter = PassthroughSubject<UserInteraction, Never>()
-        var subscriptions = Set<AnyCancellable>()
+        typealias UserInteraction = \(moduleName).UserInteraction
 
         private let viewModel: ViewModel
         
@@ -48,7 +46,7 @@ extension \(moduleName) {
         override func viewDidLoad() {
             super.viewDidLoad()
             
-            // add subscriptions to viewModel here
+            // Bind to the viewModel
         }
 
     }

--- a/Sources/VIPERCommandLine/Templates/View.swift
+++ b/Sources/VIPERCommandLine/Templates/View.swift
@@ -31,10 +31,12 @@ extension \(moduleName) {
 
     class View: \(view), VIPERView {
         
-        let interactor = PassthroughSubject<UserInteraction, Never>()
-        private var viewModel: ViewModel
+        let presenter = PassthroughSubject<UserInteraction, Never>()
+        var subscriptions = Set<AnyCancellable>()
+
+        private let viewModel: ViewModel
         
-        required init(input viewModel: ViewModel) {
+        required init(viewModel: ViewModel) {
             self.viewModel = viewModel
             super.init(nibName: nil, bundle: nil)
         }
@@ -46,18 +48,9 @@ extension \(moduleName) {
         override func viewDidLoad() {
             super.viewDidLoad()
             
-            DispatchQueue.main.async { [unowned self] in
-                self.receive(input: self.viewModel)
-            }
+            // add subscriptions to viewModel here
         }
-        
-        func receive(input viewModel: ViewModel) {
-            defer {
-                self.viewModel = viewModel
-            }
-            guard isViewLoaded else { return }
-        }
-            
+
     }
 
 }

--- a/Tests/VIPERTests/Example/Interactor.swift
+++ b/Tests/VIPERTests/Example/Interactor.swift
@@ -1,0 +1,27 @@
+import VIPER
+
+extension Example {
+
+    class Interactor: VIPER.Interactor {
+        
+        var presenterModel: PresenterModel
+        
+        private let increment: Int
+        
+        required init(entities: Entities) {
+            increment = entities.increment
+            let values = (0..<increment).map{ String($0) }
+            presenterModel = .init(values: values)
+        }
+        
+        func receive(useCase: UseCase) {
+            switch useCase {
+            case .loadValues:
+                let values = (presenterModel.values.count..<presenterModel.values.count + increment).map{ String($0) }
+                presenterModel.values = presenterModel.values + values
+            }
+        }
+                
+    }
+
+}

--- a/Tests/VIPERTests/Example/Module.swift
+++ b/Tests/VIPERTests/Example/Module.swift
@@ -1,0 +1,79 @@
+import VIPER
+        
+protocol Builder {
+    
+}
+
+protocol PresenterModelDelegate: AnyObject {
+    func valuesDidUpdate(values: [String])
+}
+
+protocol ViewModelDelegate: AnyObject {
+    func titleDidUpdate(title: String)
+    func rowsDidUpdate(rows: [String])
+}
+
+enum Example {
+    
+    struct Entities {
+        
+        var increment: Int
+
+        public init(increment: Int) {
+            self.increment = increment
+        }
+        
+    }
+    
+    enum UserInteraction {
+        case selectThis
+        case selectThat
+    }
+
+    enum UseCase {
+        case loadValues
+    }
+    
+    enum Navigation {
+        case presentSomething
+    }
+        
+    class PresenterModel {
+        
+        weak var delegate: PresenterModelDelegate?
+        
+        var values: [String] {
+            didSet {
+                delegate?.valuesDidUpdate(values: values)
+            }
+        }
+        
+        init(values: [String]) {
+            self.values = values
+        }
+        
+    }
+
+    class ViewModel {
+        
+        weak var delegate: ViewModelDelegate?
+
+        var title: String {
+            didSet {
+                delegate?.titleDidUpdate(title: title)
+            }
+        }
+        var rows: [String] {
+            didSet {
+                delegate?.rowsDidUpdate(rows: rows)
+            }
+        }
+        
+        init(title: String, rows: [String]) {
+            self.title = title
+            self.rows = rows
+        }
+        
+    }
+
+}

--- a/Tests/VIPERTests/Example/Presenter.swift
+++ b/Tests/VIPERTests/Example/Presenter.swift
@@ -1,0 +1,34 @@
+import VIPER
+
+extension Example {
+
+    class Presenter: VIPER.Presenter, PresenterModelDelegate {
+        
+        typealias UseCase = Example.UseCase
+        typealias Navigation = Example.Navigation
+        
+        let viewModel: ViewModel
+                
+        required init(presenterModel: PresenterModel) {
+            viewModel = ViewModel(title: String(presenterModel.values.count), rows: presenterModel.values)
+            
+            presenterModel.delegate = self
+        }
+        
+        func receive(userInteraction: UserInteraction) {
+            switch userInteraction {
+            case .selectThis:
+                send(.loadValues)
+            case .selectThat:
+                send(.presentSomething)
+            }
+        }
+        
+        func valuesDidUpdate(values: [String]) {
+            viewModel.title = String(values.count)
+            viewModel.rows = values
+        }
+        
+    }
+
+}

--- a/Tests/VIPERTests/Example/Router.swift
+++ b/Tests/VIPERTests/Example/Router.swift
@@ -1,0 +1,24 @@
+import VIPER
+
+extension Example {
+    
+    class Router: VIPER.Router {
+        
+        typealias View = Example.View
+        
+        var presentedSomething = false
+        
+        required init(builder: Builder) {
+
+        }
+        
+        func receive(navigation: Navigation) {
+            switch navigation {
+            case .presentSomething:
+                presentedSomething = true
+            }
+        }
+                
+    }
+
+}

--- a/Tests/VIPERTests/Example/View.swift
+++ b/Tests/VIPERTests/Example/View.swift
@@ -1,0 +1,34 @@
+#if os(macOS)
+import AppKit
+#else
+import UIKit
+#endif
+
+import VIPER
+        
+extension Example {
+
+    class View: VIPER.View, ViewModelDelegate {
+        
+        typealias UserInteraction = Example.UserInteraction
+        
+        let viewModel: ViewModel
+
+        var title: String
+        var rows: [String]
+        
+        required init(viewModel: ViewModel) {
+            self.viewModel = viewModel
+            
+            title = viewModel.title
+            rows = viewModel.rows
+            
+            viewModel.delegate = self
+        }
+        
+        func titleDidUpdate(title: String) {}
+        func rowsDidUpdate(rows: [String]) {}
+        
+    }
+
+}

--- a/Tests/VIPERTests/VIPERTests.swift
+++ b/Tests/VIPERTests/VIPERTests.swift
@@ -44,7 +44,7 @@ class VIPERTests: XCTestCase {
     
     class View: VIPERView {
         
-        let presenter = PassthroughSubject<UserInteraction, Never>()
+        let presenter = VIPERMessage<UserInteraction>()
         var subscriptions = Set<AnyCancellable>()
         var viewModel: ViewModel
 
@@ -56,8 +56,8 @@ class VIPERTests: XCTestCase {
     
     class Presenter: VIPERPresenter {
         
-        let interactor = PassthroughSubject<UseCase, Never>()
-        let router = PassthroughSubject<Navigation, Never>()
+        let interactor = VIPERMessage<UseCase>()
+        let router = VIPERMessage<Navigation>()
         var viewModel: ViewModel
         
         private var subscriptions = Set<AnyCancellable>()

--- a/Tests/VIPERTests/VIPERTests.swift
+++ b/Tests/VIPERTests/VIPERTests.swift
@@ -32,20 +32,20 @@ class VIPERTests: XCTestCase {
         let interactor = PassthroughSubject<UserInteraction, Never>()
         var viewModel: ViewModel
 
-        required init(input: ViewModel) {
-            self.viewModel = input
+        required init(viewModel: ViewModel) {
+            self.viewModel = viewModel
         }
         
-        func receive(input: ViewModel) {
-            self.viewModel = input
+        func receive(viewModel: ViewModel) {
+            self.viewModel = viewModel
         }
                 
     }
     
     class Presenter: VIPERPresenter {
         
-        static func map(input: PresenterModel) -> ViewModel {
-            return ViewModel(title: "\(input.count)")
+        static func map(presenterModel: PresenterModel) -> ViewModel {
+            return ViewModel(title: "\(presenterModel.count)")
         }
         
     }

--- a/Tests/VIPERTests/VIPERTests.swift
+++ b/Tests/VIPERTests/VIPERTests.swift
@@ -1,133 +1,22 @@
 import XCTest
 
-import Combine
 @testable import VIPER
 
-class VIPERTests: XCTestCase {
-        
-    struct Builder {}
+private extension Example {
     
-    struct Entities {
-        var increment: Int
-    }
+    typealias Components = (view: View, interactor: Interactor, presenter: Presenter, router: Router)
     
-    class PresenterModel {
-        @Published var values: [String]
-        
-        init(values: [String]) {
-            self.values = values
-        }
-    }
-    
-    enum UserInteraction {
-        case selectThis
-        case selectThat
-    }
-    
-    enum UseCase {
-        case loadValues
-    }
-    
-    enum Navigation {
-        case presentSomething
-    }
-    
-    class ViewModel {
-        @Published var title: String
-        @Published var rows: [String]
-        
-        init(title: String, rows: [String]) {
-            self.title = title
-            self.rows = rows
-        }
-    }
-    
-    class View: VIPERView {
-        
-        let presenter = VIPERMessage<UserInteraction>()
-        var subscriptions = Set<AnyCancellable>()
-        var viewModel: ViewModel
-
-        required init(viewModel: ViewModel) {
-            self.viewModel = viewModel
-        }
-                        
-    }
-    
-    class Presenter: VIPERPresenter {
-        
-        let interactor = VIPERMessage<UseCase>()
-        let router = VIPERMessage<Navigation>()
-        var viewModel: ViewModel
-        
-        private var subscriptions = Set<AnyCancellable>()
-        
-        required init(presenterModel: PresenterModel) {
-            viewModel = ViewModel(title: String(presenterModel.values.count), rows: presenterModel.values)
-            
-            presenterModel.$values.sink { [viewModel] values in
-                viewModel.title = String(values.count)
-                viewModel.rows = values
-            }.store(in: &subscriptions)
-        }
-        
-        func receive(userInteraction: UserInteraction) {
-            switch userInteraction {
-            case .selectThis:
-                interactor.send(.loadValues)
-            case .selectThat:
-                router.send(.presentSomething)
-            }
-        }
-        
-    }
-    
-    class Interactor: VIPERInteractor {
-        
-        var presenterModel: PresenterModel
-        
-        private let increment: Int
-        
-        required init(entities: Entities) {
-            increment = entities.increment
-            let values = (0..<increment).map{ String($0) }
-            presenterModel = .init(values: values)
-        }
-        
-        func receive(useCase: UseCase) {
-            switch useCase {
-            case .loadValues:
-                let values = (presenterModel.values.count..<presenterModel.values.count + increment).map{ String($0) }
-                presenterModel.values = presenterModel.values + values
-            }
-        }
-                
-    }
-    
-    class Router: VIPERRouter {
-        
-        var presentedSomething = false
-        
-        required init(builder: Builder) {
-
-        }
-        
-        func receive(navigation: Navigation, for view: View) {
-            switch navigation {
-            case .presentSomething:
-                presentedSomething = true
-            }
-        }
-                
+    static func components(entities: Entities, builder: Builder) -> Components {
+        return Module<View, Interactor, Presenter, Router>.components(entities: entities, builder: builder)
     }
 
 }
 
-extension VIPERTests {
-
+class VIPERTests: XCTestCase, Builder {
+        
     func testAssembly() {
         // arrange
-        var components = Optional(VIPERModule<View, Interactor, Presenter, Router>.components(entities: .init(increment: 3), builder: .init()))
+        var components = Optional(Example.components(entities: .init(increment: 3), builder: self))
         
         var view = components?.view // view keeps entire module alive
         weak var presenter = components?.presenter
@@ -153,19 +42,19 @@ extension VIPERTests {
 
     func testDataFlow() {
         // arrange
-        let components = VIPERModule<View, Interactor, Presenter, Router>.components(entities: .init(increment: 3), builder: .init())
+        let components = Example.components(entities: .init(increment: 3), builder: self)
         let view = components.view; let router = components.router
-        XCTAssertEqual(view.viewModel.title, "3")
-        XCTAssertEqual(view.viewModel.rows, ["0", "1", "2"])
+        XCTAssertEqual(view.title, "3")
+        XCTAssertEqual(view.rows, ["0", "1", "2"])
         XCTAssertFalse(router.presentedSomething)
 
         // act & assert
-        view.presenter.send(.selectThis)
+        view.send(.selectThis)
         XCTAssertEqual(view.viewModel.title, "6")
         XCTAssertEqual(view.viewModel.rows, ["0", "1", "2", "3", "4", "5"])
         
         // act & assert
-        view.presenter.send(.selectThat)
+        view.send(.selectThat)
         XCTAssertTrue(router.presentedSomething)
     }
 

--- a/Tests/VIPERTests/VIPERTests.swift
+++ b/Tests/VIPERTests/VIPERTests.swift
@@ -3,11 +3,11 @@ import XCTest
 @testable import VIPER
 
 private extension Example {
+        
+    typealias Module = VIPER.Module<View, Interactor, Presenter, Router>
     
-    typealias Components = (view: View, interactor: Interactor, presenter: Presenter, router: Router)
-    
-    static func components(entities: Entities, builder: Builder) -> Components {
-        return Module<View, Interactor, Presenter, Router>.components(entities: entities, builder: builder)
+    static func components(entities: Entities, builder: Builder) -> Module.Components {
+        return Module.components(entities: entities, builder: builder)
     }
 
 }


### PR DESCRIPTION
This release drastically alters VIPER from a unidirectional to bidirectional implementation: 

* It rearranges VIPER components to more closely model the traditional definition. View <-> Presenter <-> Interactor
* Similarly, Presenters now talk to Routers to make decisions regarding navigation. 
* The role of `PresenterModel` and `ViewModel` is clearer - they provide state information to their respective counterparts
* Mechanics of message passing are simplified - ViewModel and PresenterModel are only provided as upon initialisation as dependencies. Consumers can use publishers or delegation to subscribe to updates. 
* Combine is removed as a dependency, which lowers the minimum OS requirements.
* `AnyObject` requirement forces all VIPER objects to be implemented as classes. This allows for some Objective-C runtime magic to abstract message passing mechanics.
* VIPER components don't need to declare Combine publishers for message passing; subscriptions are also maintained under the hood.
* Restored weakly-held `view` property on Routers. 